### PR TITLE
Fixed image reference

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -11,7 +11,7 @@ style="background-image: url('https://images.pexels.com/photos/255379/pexels-pho
         </h3>
         <h2 class="text-gray-800 text-md"> I am eager to increase my analytical skills and Cloud Technologies knowledge.</h2>
         <img class="grid justify-items-end h-40 mb-6"
-          src="./_includes/static/avatar.png" alt="Cury hair avatar">
+          src="/static/avatar.png" alt="Cury hair avatar">
         {# <ul >
         {% for info in collections.info %}
           <li> <a href="{{ info.url }}">{{ info.data.title }}</a></li>


### PR DESCRIPTION
This PR fixes the broken image path:

<img width="694" alt="Screenshot 2022-04-28 at 07 43 54" src="https://user-images.githubusercontent.com/205629/165693193-486a85b2-fd9e-4f9f-aa2e-e1c05c4fc210.png">

## Background

This is a common gotcha when coming from React/Next.js or similar JavaScript-heavy frameworks. What framework like React generally do (through bundlers like Webpack) is to let you import image files directly in your code.

### Referencing assets with React + Webpack

Here's an example:

```javascript
// AvatarImg.jsx

import avatar from './_includes/static/avatar.png'

export function AvatarImg() {
  return (
    <img class="grid justify-items-end h-40 mb-6"
         src="{avatar}"/>
  )
}
```

In this case, what would happen is that once you "build" your application, the module bundler will kick in and "look" at all your import statements.

Generally module bundlers like Webpack are configured to understand different types of files being imported.

In this case, the bundler will understand that you are trying to load a PNG image. The configuration also tells the module bundler what to do with images. Generally the behaviour is to copy the image in the build target folder and put the image path in the `avatar` variable.

Because of all this processing, when using React, you generally reference images using a relative path to the source file (`'./_includes/static/avatar.png'`) in your code and let the module bundler doing the copy of the assets and give you the resulting path.

### Referencing assets with Eleventy

Eleventy takes a dramatically different approach here.

Eleventy doesn't use a module bundler and it's very light on processing your source code. You can decide to use bundlers like webpack if you want to, but it's entirely up to you to do all of that configuration.

It's generally unnecessary to do that. Full disclaimer, this is actually one of the reasons why I like Eleventy. It generally keeps things simple and close to the bare web fundamentals, without any additional magic.

What this means is that **Eleventy doesn't really know in your templates what the final path of your image will be**, so it's up to you to make sure the template will "produce" the final image path.

Because you have the following in your Eleventy config:

```javascript
eleventyConfig.addPassthroughCopy({ './src/_includes/static': 'static' })
```

All the static assets will be copied as follow:

```plain
{project_folder}/src/_includes/static/* -> {build_folder}/static/*
```

In the case of your avatar:

```plain
{project_folder}/src/_includes/static/avatar.png -> {build_folder}/static/avatar.png
```

When you publish the website (or run it locally), all the files are loaded from the build folder (check out what's inside your `dist` folder if you are curious), so the final path for your avatar will be `/static/avatar.png` and that's why you need to use this in your template.

I hope that this helps in terms of understanding the different models used by Eleventy and React/Webpack.

PS: I love the avatar :)

